### PR TITLE
Add support when the URL is a table itself

### DIFF
--- a/src/lib/notional/index.ts
+++ b/src/lib/notional/index.ts
@@ -6,9 +6,9 @@ import {
   TableKeySet,
   TableOptions,
 } from './types';
-import Block from '../block';
 import { URL } from 'url';
 import Table from '../table';
+import Block from '../block';
 
 export class Notional {
   private userId: string;

--- a/src/lib/notional/index.ts
+++ b/src/lib/notional/index.ts
@@ -7,8 +7,8 @@ import {
   TableOptions,
 } from './types';
 import Block from '../block';
-import Table from '../table';
 import { URL } from 'url';
+import Table from '../table';
 
 export class Notional {
   private userId: string;

--- a/src/lib/notional/index.ts
+++ b/src/lib/notional/index.ts
@@ -6,9 +6,9 @@ import {
   TableKeySet,
   TableOptions,
 } from './types';
-import { URL } from 'url';
-import Table from '../table';
 import Block from '../block';
+import Table from '../table';
+import { URL } from 'url';
 
 export class Notional {
   private userId: string;
@@ -112,7 +112,7 @@ export class Notional {
     );
 
     const tableKeys = Object.values(recordMap.block)
-      .filter(block => block.value && block.value.type === 'collection_view')
+      .filter(block => block.value && (block.value.type === 'collection_view' || block.value.type === 'collection_view_page'))
       .reduce((keyObject: TableKeyCache, collection) => {
         const collectionId = collection.value.collection_id;
         const tableUrl = `${baseUrl}/${collectionId}`;

--- a/src/lib/notional/types.ts
+++ b/src/lib/notional/types.ts
@@ -88,7 +88,8 @@ export type BlockType =
   | 'datetime'
   | 'user'
   | 'person'
-  | 'collection_view';
+  | 'collection_view'
+  | 'collection_view_page';
 
 export type PluralBlockType = 'tables';
 


### PR DESCRIPTION
This fixes an issue where the library doesn't find a table unless it was added as an inline table.

PS. there's some garbage commits, because I always just use "Squash and merge" on my PRs so it comes out as a single commit to master. Not sure if you have a preference.