### PR TITLE
Allow passing no filters to retrieve all rows in a table

### DIFF
--- a/src/lib/table/index.ts
+++ b/src/lib/table/index.ts
@@ -204,24 +204,22 @@ export default class Table {
     ) as Schema;
 
     const rowData = blocks.map(block => {
-      if (block.value.properties) {
-        return {
-          block_id: block.value.id,
-          block_data: block.value.properties,
-        };
-      }
+      return {
+        block_id: block.value.id,
+        block_data: block.value.properties,
+      };
     });
 
     const filterKeys = Object.keys(filters);
 
     return rowData
       .map(row => {
-        let filterOutRow = true;
+        let filterOutRow = (filterKeys.length > 0) ? true : false;
 
         const formattedData = Object.entries(schema).reduce(
           (data, [key, headingData]) => {
             let value;
-            if (!row || !row.block_data || !row.block_data[key]) {
+            if (!row.block_data || !row.block_data[key]) {
               value = this.getDefaultValueForType(headingData.type);
             } else {
               value = this.formatRawDataToType(
@@ -229,10 +227,9 @@ export default class Table {
                 headingData.type,
               );
             }
-
             if (
-              filterKeys.includes(headingData.name) &&
-              filters[headingData.name] === value
+              (filterKeys.includes(headingData.name) &&
+              filters[headingData.name] === value)
             ) {
               filterOutRow = false;
             }

--- a/src/lib/table/index.ts
+++ b/src/lib/table/index.ts
@@ -228,8 +228,8 @@ export default class Table {
               );
             }
             if (
-              (filterKeys.includes(headingData.name) &&
-              filters[headingData.name] === value)
+              filterKeys.includes(headingData.name) &&
+              filters[headingData.name] === value
             ) {
               filterOutRow = false;
             }


### PR DESCRIPTION
My use case is that I want to be able to wipe out all the rows in a table with `table.deleteRows()`. However, this calls `getFilteredBlockData()` underneath, which actually returns 0 results unless you give it something. Additionally, i wanted to be able to remove _empty rows_, which were being filtered out. This update works for my case, but I have not thought about how it could affect other methods.