### PR TITLE
add method to add columns to a table

### DIFF
--- a/src/lib/notional/types.ts
+++ b/src/lib/notional/types.ts
@@ -194,7 +194,7 @@ export type Comment = {
 };
 
 export type BaseSchemaCell = {
-  id: string;
+  id?: string;
   name: string;
   type: string;
 };

--- a/src/lib/table/index.ts
+++ b/src/lib/table/index.ts
@@ -460,7 +460,14 @@ export default class Table {
   public async updateColumns(
     schema: Record<
       string,
-      { id?: string; options?: Partial<MultiSelectOption>[]; type: string }
+      {
+        id?: string;
+        options?: (Omit<MultiSelectOption, 'color' | 'id'> & {
+          color?: string;
+          id?: string;
+        })[];
+        type: string;
+      }
     >,
   ) {
     const collectionBlocks = await this.queryCollection(this.keys);
@@ -470,6 +477,19 @@ export default class Table {
       `recordMap.collection.${this.keys.collectionId}.value.schema`,
       {},
     ) as Schema;
+
+    const rawHash = Object.entries(rawSchema)
+      .map(([id, fields]) => fields.name + fields.options?.map(o => o.value))
+      .sort()
+      .join();
+    const inputHash = Object.entries(schema)
+      .map(([name, fields]) => name + fields.options?.map(o => o.value))
+      .sort()
+      .join();
+    if (rawHash === inputHash) {
+      // save some I/O and dont update
+      return;
+    }
 
     const newSchema = Object.entries(schema).reduce<Schema>(
       (newSchema, [key, headingData]) => {
@@ -486,7 +506,13 @@ export default class Table {
             ? existing[0]
             : crypto.randomFillSync(Buffer.alloc(2)).toString('hex');
         }
-        newSchema[id] = { name: key, type: headingData.type };
+
+        newSchema[id] = {
+          name: key,
+          options: rawSchema[id]?.options,
+          type: headingData.type,
+        };
+
         if (headingData.options) {
           newSchema[id].options = headingData.options.reduce<
             MultiSelectOption[]

--- a/src/lib/table/index.ts
+++ b/src/lib/table/index.ts
@@ -506,6 +506,8 @@ export default class Table {
       rawSchema,
     );
 
-    return await this.transactionManager.setSchema(newSchema);
+    await this.transactionManager.setSchema(newSchema);
+
+    this.schema = null;
   }
 }

--- a/src/lib/transaction-manager/index.ts
+++ b/src/lib/transaction-manager/index.ts
@@ -2,7 +2,7 @@ import { v4 as uuid } from 'uuid';
 import moment from 'moment';
 import flatten from 'lodash/flatten';
 import { AxiosInstance } from 'axios';
-import { TableKeySet, UserTextNode } from '../notional/types';
+import { Schema, TableKeySet, UserTextNode } from '../notional/types';
 import { UpdateData } from '../table/types';
 
 const NOTION_STAND_IN_NOTATION = '‣';
@@ -137,6 +137,26 @@ export default class TransactionManager {
       ],
     }));
 
+    return await this.submitTransaction(transactions);
+  }
+
+  public async setSchema(schema: Schema) {
+
+    const now = new Date().getTime();
+    const transactions = [{
+      id: uuid(),
+      operations: [
+        {
+          id: this.keys?.collectionId,
+          table: 'collection',
+          path: [],
+          command: 'update',
+          args: {
+            schema
+          },
+        }
+      ]
+    }];
     return await this.submitTransaction(transactions);
   }
 

--- a/src/lib/transaction-manager/index.ts
+++ b/src/lib/transaction-manager/index.ts
@@ -141,22 +141,23 @@ export default class TransactionManager {
   }
 
   public async setSchema(schema: Schema) {
-
-    const now = new Date().getTime();
-    const transactions = [{
-      id: uuid(),
-      operations: [
-        {
-          id: this.keys?.collectionId,
-          table: 'collection',
-          path: [],
-          command: 'update',
-          args: {
-            schema
+    const transactions = [
+      {
+        id: uuid(),
+        operations: [
+          {
+            id: this.keys?.collectionId,
+            table: 'collection',
+            path: [],
+            command: 'update',
+            args: {
+              schema,
+            },
           },
-        }
-      ]
-    }];
+        ],
+      },
+    ];
+
     return await this.submitTransaction(transactions);
   }
 


### PR DESCRIPTION
I'm not sure if you want to include this, or maybe this lib should only expose lower-level methods, so I'm open to suggestions! For my use case, I have an app that updates columns and I'd prefer to be able to create them automatically than ask people to set it up in Notion first. Some things I considered:
- I used the `Schema` interface as input, but it might be more intuitive to use an array of settings?
- it won't add duplicate columns by name
- you can pass in the id of an existing column to rename it
- it won't remove any existing columns. It's easy enough to delete them manually, and I wanted to avoid deleting some data we don't know about.